### PR TITLE
Review: fix lint, keep custom coverage commands

### DIFF
--- a/hardware/lint/iob_fp_mul_waiver.vlt
+++ b/hardware/lint/iob_fp_mul_waiver.vlt
@@ -1,0 +1,12 @@
+// DESCRIPTION: Verilator output: Waivers generated with --waiver-output
+
+`verilator_config
+
+// Unused module outputs
+lint_off -rule PINCONNECTEMPTY -file "**/iob_fp_mul.v" -match "Cell pin connected by name with empty reference: 'sub_normal_o'"
+
+lint_off -rule PINCONNECTEMPTY -file "**/iob_fp_mul.v" -match "Cell pin connected by name with empty reference: 'sub_normal_o'"
+
+// Keep bits for full multiplication precision
+lint_off -rule UNUSEDSIGNAL -file "**/iob_fp_mul.v" -match "Bits of signal are not used: 'Temp_Mantissa'[19:0]"
+

--- a/hardware/simulation/child_sim_build.mk
+++ b/hardware/simulation/child_sim_build.mk
@@ -1,0 +1,13 @@
+# VersatAI sim_build.mk
+# Imported by iob_system's sim_build.mk
+CUSTOM_COVERAGE_FLAGS=cov_annotated
+CUSTOM_COVERAGE_FLAGS+=-E iob_uut.v
+CUSTOM_COVERAGE_FLAGS+=-E versat_ai_mwrap.v
+CUSTOM_COVERAGE_FLAGS+=-E iob_rom_sp.v
+CUSTOM_COVERAGE_FLAGS+=-E iob_uart.v
+CUSTOM_COVERAGE_FLAGS+=-E iob_uart_core.v
+CUSTOM_COVERAGE_FLAGS+=-E iob_uart_csrs.v
+CUSTOM_COVERAGE_FLAGS+=-E iob_axi_ram.v
+CUSTOM_COVERAGE_FLAGS+=-E iob_ram_t2p_be.v
+CUSTOM_COVERAGE_FLAGS+=-E iob_ram_t2p.v
+CUSTOM_COVERAGE_FLAGS+=-o versat_ai_coverage.rpt

--- a/hardware/src/FloatToLargeInteger.v
+++ b/hardware/src/FloatToLargeInteger.v
@@ -7,9 +7,6 @@ module FloatToLargeInteger (
    output reg [278:0] out_o  // Much higher order
 );
 
-   localparam EXP_W = 8;
-   localparam BIAS = 2 ** (EXP_W - 1) - 1;
-
    wire [  7:0] exponent = in_i[30:23];
 
    wire [ 23:0] mantissa = {(exponent == 8'h00 ? 1'b0 : 1'b1), in_i[22:0]};

--- a/hardware/src/iob_fp_add.v
+++ b/hardware/src/iob_fp_add.v
@@ -41,7 +41,7 @@ module iob_fp_add #(
                 )
    special_op_a
      (
-      .data_i       (op_a_i),
+      .data_i       (op_a_i[DATA_W-2:0]),
 
       .nan_o        (op_a_nan),
       .infinite_o   (op_a_inf),

--- a/hardware/src/iob_fp_mul.v
+++ b/hardware/src/iob_fp_mul.v
@@ -35,57 +35,45 @@ module iob_fp_mul #(
 
    // Special cases
 `ifdef SPECIAL_CASES
-   wire                     op_a_nan, op_a_inf, op_a_zero, op_a_sub;
+   wire                     op_a_nan, op_a_inf, op_a_zero;
    iob_fp_special #(
                 .DATA_W(DATA_W),
                 .EXP_W(EXP_W)
                 )
    special_op_a
      (
-      .data_i      (op_a_i),
+      .data_i      (op_a_i[DATA_W-2:0]),
 
       .nan_o        (op_a_nan),
       .infinite_o   (op_a_inf),
       .zero_o       (op_a_zero),
-      .sub_normal_o (op_a_sub)
+      .sub_normal_o ()
       );
 
-   wire                     op_b_nan, op_b_inf, op_b_zero, op_b_sub;
+   wire                     op_b_nan, op_b_inf, op_b_zero;
    iob_fp_special #(
                 .DATA_W(DATA_W),
                 .EXP_W(EXP_W)
                 )
    special_op_b
      (
-      .data_i       (op_b_i),
+      .data_i       (op_b_i[DATA_W-2:0]),
 
       .nan_o        (op_b_nan),
       .infinite_o   (op_b_inf),
       .zero_o       (op_b_zero),
-      .sub_normal_o (op_b_sub)
+      .sub_normal_o ()
       );
 
    wire                     special = op_a_nan | op_a_inf | op_b_nan | op_b_inf;
-   wire [DATA_W-1:0]        res_special = (op_a_nan | op_b_nan)? `NAN:
-                                          (op_a_inf & op_b_inf)? `NAN:
-                                        (op_a_zero | op_b_zero)? `NAN:
-                                                                 `INF(op_b_i[DATA_W-1] ^ op_b_i[DATA_W-1]);
 
 wire any_nan = op_a_nan | op_b_nan;
 wire any_inf = op_a_inf | op_b_inf;
 wire any_zero = op_a_zero | op_b_zero;
 
-reg any_nan_1,any_nan_2,any_nan_3;
-reg any_inf_1,any_inf_2,any_inf_3;
 reg any_zero_1,any_zero_2,any_zero_3;
 
 always @(posedge clk_i) begin
-   any_nan_1 <= any_nan;
-   any_nan_2 <= any_nan_1;
-   any_nan_3 <= any_nan_2;
-   any_inf_1 <= any_inf;
-   any_inf_2 <= any_inf_1;
-   any_inf_3 <= any_inf_2;
    any_zero_1 <= any_zero;
    any_zero_2 <= any_zero_1;
    any_zero_3 <= any_zero_2;
@@ -219,7 +207,6 @@ end
                                                   (any_nan ? `NAN : 
                                                              (any_inf ? `INF(Sign) : {Sign, Exponent, Mantissa}));
 
-   //wire [DATA_W-1:0]        res_in  = special? res_special: {Sign, Exponent, Mantissa};
    wire                     done_in = special? start_i: done_int3;
 `else
    wire [DATA_W-1:0]        res_in  = {Sign, Exponent, Mantissa};

--- a/hardware/src/iob_fp_special.v
+++ b/hardware/src/iob_fp_special.v
@@ -5,7 +5,7 @@ module iob_fp_special #(
                     parameter EXP_W = 8
                     )
    (
-    input [DATA_W-1:0] data_i,
+    input [DATA_W-2:0] data_i,
 
     output             nan_o,
     output             infinite_o,
@@ -15,7 +15,6 @@ module iob_fp_special #(
 
    localparam MAN_W = DATA_W-EXP_W;
 
-   wire                sign = data_i[DATA_W-1];
    wire [EXP_W-1:0]    exponent = data_i[DATA_W-2 -: EXP_W];
    wire [MAN_W-2:0]    mantissa = data_i[MAN_W-2:0];
 


### PR DESCRIPTION
- fix lint warnings
- update lint script to return non-0 if warnings were found
- add back custom coverage flags (use `child_sim_build.mk` feature)